### PR TITLE
fix: 修复analysis中的图片没有被正确解析的问题

### DIFF
--- a/ewt.js
+++ b/ewt.js
@@ -56,8 +56,12 @@
 }
 .ewt-modal-body .q-num { font-weight: bold; color: #333; }
 .ewt-modal-body .q-ans { color: #e74c3c; margin: 4px 0; }
-.ewt-modal-body .q-ans img, .ewt-modal-body .q-parse img {
+.ewt-modal-body .q-ans img {
     max-width: 100%; vertical-align: middle; max-height: 40px;
+}
+.ewt-modal-body .q-parse img {
+    max-width: 100%; height: auto; max-height: 220px;
+    vertical-align: middle; margin-top: 6px;
 }
 .ewt-modal-body .q-know { color: #888; font-size: 12px; }
 .ewt-modal-body .q-parse { color: #555; font-size: 12px; white-space: pre-wrap; margin-top: 4px; }
@@ -184,7 +188,8 @@
             if (r.analysis) {
                 const parseDiv = el('div', 'q-parse');
                 parseDiv.appendChild(txt('解析: '));
-                parseDiv.appendChild(safeHtmlToFragment(r.analysis));
+                parseDiv.insertAdjacentHTML("beforeend", r.analysis.replace(/\\</g, "<").replace(/\\:/g, ":"));
+                console.log(JSON.stringify(r.analysis.replace(/\\</g, "<").replace(/\\:/g, ":")));
                 qDiv.appendChild(parseDiv);
             }
 
@@ -441,6 +446,7 @@
             return questions;
         }
         throw new Error(JSON.stringify(data));
+
     };
 
     const updateReport = async (reportId, bizCode) => {
@@ -489,7 +495,7 @@
     const cleanHtmlKeepImg = (text) => {
         if (!text) return '';
         text = text.replace(/<img[^>]*Wirisformula[^>]*src="([^"]*)"[^>]*>/g,
-            '<img src="$1" style="max-height:36px;vertical-align:middle;" />');
+            '<img src="$1" />');
         text = text.replace(/<br[^>]*>/g, '\n');
         text = text.replace(/<(?!img\b|\/img\b)[^>]+>/g, '');
         text = text.replace(/&ldquo;/g, '\u201c').replace(/&rdquo;/g, '\u201d');


### PR DESCRIPTION
调整图片显示的样式避免过小(

## Summary by Sourcery

改进题目解析内容中图片的渲染，确保图片被正确解析并以合适的尺寸显示。

Bug 修复：
- 修复解析内容 HTML 时的解析问题，将转义字符还原，并确保嵌入在解析中的图片可以正确渲染。

功能增强：
- 调整弹窗样式，使答案区域和解析区域中的图片使用不同的尺寸规则，允许解析内容中的图片显示得更大。
- 在清理 HTML 时，简化应用于 Wiris 公式图片的行内样式，避免对其显示进行过度限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve rendering of images in question analysis content to ensure they are correctly parsed and displayed at appropriate sizes.

Bug Fixes:
- Fix analysis content HTML parsing so escaped characters are converted back and images embedded in analysis render properly.

Enhancements:
- Adjust modal styles so answer and analysis images use different sizing rules, allowing larger images in analysis content.
- Simplify inline styles applied to Wiris formula images when cleaning HTML to avoid overly constraining their display.

</details>